### PR TITLE
Update Brute Force Integration.ipynb

### DIFF
--- a/Brute Force Integration.ipynb
+++ b/Brute Force Integration.ipynb
@@ -98,7 +98,7 @@
     "    \n",
     "    elif (mu == 1) and (l % 2 != 0):\n",
     "        \n",
-    "        G = [lambda x, y: (1-f) * x ** (l - 3) * y * z(x, y) ** 3, lambda x, y: 0]\n",
+    "        G = [lambda x, y: x ** (l - 3) * y * z(x, y) ** 3, lambda x, y: 0]\n",
     "    \n",
     "    else:\n",
     "        \n",


### PR DESCRIPTION
Removed the factor of `1 - f` in the case `mu = 1, l odd` and now the expressions agree exactly when `theta = 0` (you should check the math).